### PR TITLE
Fix for GRAILS-6537, 6696 and 6697

### DIFF
--- a/grails-maven-archetype.iml
+++ b/grails-maven-archetype.iml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<module MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
+<?xml version="1.0" encoding="UTF-8"?>
+<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
@@ -11,3 +11,4 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
+

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -152,14 +152,6 @@
       <url>http://repository.jboss.com/maven2/</url>
     </repository>
     
-	  <!-- Required to get hold of JTA -->
-    <repository>
-      <id>maven2-repository.dev.java.net</id>
-      <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/2/</url>
-      <layout>default</layout>
-    </repository>
-    
     <repository>
       <id>Codehaus Snapshots</id>
       <url>http://snapshots.repository.codehaus.org</url>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -96,21 +96,8 @@
       <version>${ehcache-core.version}</version>
       <exclusions>
         <exclusion>
-          <artifactId>jms</artifactId>
-        </exclusion>
-        
-        <exclusion>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        
-        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        
-        <!-- We have JCL-over-SLF4J instead. -->
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -145,13 +145,14 @@
   </dependencies>
   
   <repositories>
-    <!-- Required to get hold of JTA -->
+	  <!-- Required to get hold of javassist:javassist -->
     <repository>
       <id>jboss.org</id>
       <name>jboss.org</name>
       <url>http://repository.jboss.com/maven2/</url>
     </repository>
     
+	  <!-- Required to get hold of JTA -->
     <repository>
       <id>maven2-repository.dev.java.net</id>
       <name>Java.net Repository for Maven</name>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -151,31 +151,7 @@
       <name>jboss.org</name>
       <url>http://repository.jboss.com/maven2/</url>
     </repository>
-    
-    <repository>
-      <id>Codehaus Snapshots</id>
-      <url>http://snapshots.repository.codehaus.org</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
   </repositories>
-  
-  <pluginRepositories>
-    <pluginRepository>
-      <id>Codehaus Snapshots</id>
-      <url>http://snapshots.repository.codehaus.org</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </pluginRepository>
-  </pluginRepositories>
   
   <build>
     <pluginManagement />


### PR DESCRIPTION
Improvements to the archetype. Remove old obsolete exclusions and unneeded repositories, to clean up the pom.
http://jira.codehaus.org/browse/GRAILS-6537
http://jira.codehaus.org/browse/GRAILS-6696
http://jira.codehaus.org/browse/GRAILS-6697
