### PR TITLE
Fix for GRAILS-6756: Maven pom file created by grails-maven-archetype includes too many jar dependencies when running mvn grails:war.

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -21,18 +21,120 @@
       <groupId>org.grails</groupId>
       <artifactId>grails-bootstrap</artifactId>
       <version>${grails.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.gpars</groupId>
+          <artifactId>gpars</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.gant</groupId>
+          <artifactId>gant_groovy1.7</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.gparallelizer</groupId>
+          <artifactId>GParallelizer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.gant</groupId>
+          <artifactId>gant_groovy1.6</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-launcher</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>
       <groupId>org.grails</groupId>
       <artifactId>grails-crud</artifactId>
       <version>${grails.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.grails</groupId>
+          <artifactId>grails-docs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-launcher</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-test</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>radeox</groupId>
+          <artifactId>radeox</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-digester</groupId>
+          <artifactId>commons-digester</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.persistence</groupId>
+          <artifactId>persistence-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>
       <groupId>org.grails</groupId>
       <artifactId>grails-gorm</artifactId>
       <version>${grails.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-launcher</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-digester</groupId>
+          <artifactId>commons-digester</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-commons-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>antlr</groupId>
+          <artifactId>antlr</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>
@@ -45,7 +147,13 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <version>1.2</version>
+      <version>1.1.2</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>taglibs</groupId>
+      <artifactId>standard</artifactId>
+      <version>1.1.2</version>
     </dependency>
     
     <!-- Grails defaults to Ehache for the second-level Hibernate cache. -->
@@ -74,8 +182,18 @@
       <version>1.7.1</version>
       <exclusions>
         <exclusion>
+          <artifactId>jms</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <!-- We have JCL-over-SLF4J instead. -->
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -90,9 +208,21 @@
     <!-- Use Log4J for logging. This artifact also pulls in the Log4J JAR. -->
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.5.8</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.5.8</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- Needed in the case of AOP usage -->
@@ -107,6 +237,50 @@
       <artifactId>aspectjrt</artifactId>
       <version>1.6.8</version>
     </dependency>
+    
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.15</version>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jdmk</groupId>
+          <artifactId>jmxtools</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jmx</groupId>
+          <artifactId>jmxri</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.mail</groupId>
+          <artifactId>mail</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.3</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-pool</groupId>
+      <artifactId>commons-pool</artifactId>
+      <version>1.5.3</version>
+    </dependency>
+    
   </dependencies>
   
   <repositories>


### PR DESCRIPTION
When using the grails-maven-archetype to create a new grails project, the resulting project produces different results when running 'grails war' compared to 'mvn grails:war' (the war created by 'grails war' is 21Mb, while the war created by 'mvn grails:war' is 32Mb).

This is caused by the default pom.xml file generated by the grails-maven-archetype to not properly exclude unwanted, transitive dependencies. Also, some versions for dependent jars differ between the created war files.

This commit fixes the problem by
- Adding dependency exclusions to
  - grails-bootstrap
  - grails-crud
  - grails-gorm
  - ehcache-core
    to exclude surplus jar dependencies
- Adding explicit dependencies to get correct versions for
  - jstl
  - log4j
  - commons-codec
  - commons-collections
  - commons-pool
- Adding explicit dependency to include missing standard-1.1.2.jar

The resulting pom.xml produces a war file with identical dependent jars as 'grails war'. 
