### PR TITLE
Updated dependencies to align with Grails 1.3.7 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.grails</groupId>
   <artifactId>grails-maven-archetype</artifactId>
-  <version>1.3.6</version>
+  <version>1.3.7.BUILD-SNAPSHOT</version>
   
   <name>Maven archetype for Grails projects</name>
   <description>Maven archetype for Grails projects.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.grails</groupId>
   <artifactId>grails-maven-archetype</artifactId>
-  <version>1.3.7.BUILD-SNAPSHOT</version>
+  <version>1.3.7</version>
   
   <name>Maven archetype for Grails projects</name>
   <description>Maven archetype for Grails projects.</description>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -21,18 +21,120 @@
       <groupId>org.grails</groupId>
       <artifactId>grails-bootstrap</artifactId>
       <version>${grails.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.gpars</groupId>
+          <artifactId>gpars</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.gant</groupId>
+          <artifactId>gant_groovy1.7</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.gparallelizer</groupId>
+          <artifactId>GParallelizer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.gant</groupId>
+          <artifactId>gant_groovy1.6</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-launcher</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>
       <groupId>org.grails</groupId>
       <artifactId>grails-crud</artifactId>
       <version>${grails.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.grails</groupId>
+          <artifactId>grails-docs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-launcher</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-test</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>radeox</groupId>
+          <artifactId>radeox</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-digester</groupId>
+          <artifactId>commons-digester</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.persistence</groupId>
+          <artifactId>persistence-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>
       <groupId>org.grails</groupId>
       <artifactId>grails-gorm</artifactId>
       <version>${grails.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-launcher</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-digester</groupId>
+          <artifactId>commons-digester</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-commons-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>antlr</groupId>
+          <artifactId>antlr</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>
@@ -45,7 +147,13 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <version>1.2</version>
+      <version>1.1.2</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>taglibs</groupId>
+      <artifactId>standard</artifactId>
+      <version>1.1.2</version>
     </dependency>
     
     <!-- Grails defaults to Ehache for the second-level Hibernate cache. -->
@@ -74,8 +182,18 @@
       <version>1.7.1</version>
       <exclusions>
         <exclusion>
+          <artifactId>jms</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <!-- We have JCL-over-SLF4J instead. -->
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -90,9 +208,21 @@
     <!-- Use Log4J for logging. This artifact also pulls in the Log4J JAR. -->
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.5.8</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.5.8</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- Needed in the case of AOP usage -->
@@ -107,6 +237,50 @@
       <artifactId>aspectjrt</artifactId>
       <version>1.6.8</version>
     </dependency>
+    
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.15</version>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jdmk</groupId>
+          <artifactId>jmxtools</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jmx</groupId>
+          <artifactId>jmxri</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.jms</groupId>
+          <artifactId>jms</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.mail</groupId>
+          <artifactId>mail</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.3</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-pool</groupId>
+      <artifactId>commons-pool</artifactId>
+      <version>1.5.3</version>
+    </dependency>
+    
   </dependencies>
   
   <repositories>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
   <url>http://www.myorganization.org</url>
   
   <properties>
-    <grails.version>1.3.6</grails.version>
+    <grails.version>1.3.7.BUILD-SNAPSHOT</grails.version>
   </properties>
   
   <dependencies>
@@ -204,7 +204,13 @@
       <version>1.5.8</version>
       <scope>runtime</scope>
     </dependency>
-    
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.16</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Needed in the case of AOP usage -->
     <dependency>
       <groupId>org.aspectj</groupId>
@@ -221,7 +227,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
+      <version>1.4</version>
     </dependency>
     
     <dependency>
@@ -233,21 +239,16 @@
     <dependency>
       <groupId>commons-pool</groupId>
       <artifactId>commons-pool</artifactId>
-      <version>1.5.3</version>
+      <version>1.5.5</version>
     </dependency>
     
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>jta</artifactId>
+      <version>1.1</version>
+    </dependency>
+
   </dependencies>
-  
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.16</version>
-        <scope>runtime</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   
   <repositories>
 	  <!-- Required to get hold of javassist:javassist -->

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -130,10 +130,6 @@
           <groupId>antlr</groupId>
           <artifactId>antlr</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     
@@ -182,18 +178,8 @@
       <version>1.7.1</version>
       <exclusions>
         <exclusion>
-          <artifactId>jms</artifactId>
-        </exclusion>
-        <exclusion>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <!-- We have JCL-over-SLF4J instead. -->
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
   <url>http://www.myorganization.org</url>
   
   <properties>
-    <grails.version>1.3.7.BUILD-SNAPSHOT</grails.version>
+    <grails.version>1.3.7</grails.version>
   </properties>
   
   <dependencies>


### PR DESCRIPTION
Hi,

I'm very pleased to see that the Maven integration now seems to work correctly again in the 1.3.7 branch!

I have updated the grails-maven-archetype to align with grails 1.3.7.BUILD-SNAPSHOT:
- Updated commons-codec to 1.4.
- Updated commons-pool to 1.5.5.
- Added explicit log4j dependency
- Added javax.transaction:jta dependency.

With these changes, 'grails war' and 'mvn grails:war' produces equivalent results.

Note: This change also requires grails-maven to be updated to 1.3.7.BUILD-SNAPSHOT - it is currently at 1.3.6 in the master branch. It requires no further changes, though.
