### PR TITLE
update maven plugin for Grails 2.3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.grails</groupId>
   <artifactId>grails-maven-archetype</artifactId>
-  <version>2.3.8</version>
+  <version>2.3.11</version>
   <packaging>jar</packaging>
   
   <name>Maven archetype for Grails projects</name>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
   <url>http://www.myorganization.org</url>
   
   <properties>
-    <grails.version>2.3.8</grails.version>
+    <grails.version>2.3.11</grails.version>
   </properties>
 
   <dependencies>
@@ -34,7 +34,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>tomcat</artifactId>
-        <version>7.0.52.1</version>
+        <version>7.0.54</version>
         <type>zip</type>
         <scope>provided</scope>
     </dependency>
@@ -42,7 +42,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>hibernate</artifactId>
-        <version>3.6.10.13</version>
+        <version>3.6.10.16</version>
         <type>zip</type>
         <scope>compile</scope>
     </dependency>   
@@ -50,7 +50,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>scaffolding</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.3</version>
         <type>zip</type>
         <scope>compile</scope>
     </dependency>   
@@ -58,7 +58,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>jquery</artifactId>
-        <version>1.11.0.1</version>
+        <version>1.11.1</version>
         <type>zip</type>
         <scope>runtime</scope>
     </dependency> 
@@ -67,7 +67,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>resources</artifactId>
-        <version>1.2.7</version>
+        <version>1.2.8</version>
         <type>zip</type>
         <scope>runtime</scope>
     </dependency> 
@@ -83,7 +83,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>cache</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.7</version>
         <type>zip</type>
         <scope>runtime</scope>
     </dependency>                


### PR DESCRIPTION
When using a pom build, need the grails-maven-plugin version to match up with the grails version. 
