### PR TITLE
Update pom.xml

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -22,6 +22,7 @@
         <groupId>org.grails</groupId>
         <artifactId>grails-dependencies</artifactId>
         <version>${grails.version}</version>
+        <type>pom</type>
     </dependency>    
 
     <dependency>


### PR DESCRIPTION
"mvn initialize" fails with maven 3.2.1 due resolve dependency to "org.grails:grails-dependencies:jar:2.3.8". Since this depency is only distributed as pom and not as jar. After added type with value pom to dependency "grails-dependencies" so maven 3.2.1 is able to build correctly.

fixes [https://jira.grails.org/browse/MAVEN-218]
