### PR TITLE
Update versions for 2.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.grails</groupId>
   <artifactId>grails-maven-archetype</artifactId>
-  <version>2.4.0.RC1</version>
+  <version>2.4.3</version>
   <packaging>jar</packaging>
   
   <name>Maven archetype for Grails projects</name>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
   <url>http://www.myorganization.org</url>
   
   <properties>
-    <grails.version>2.4.0.RC1</grails.version>
+    <grails.version>2.4.3</grails.version>
   </properties>
 
   <dependencies>
@@ -49,7 +49,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>tomcat</artifactId>
-        <version>7.0.52.1</version>
+        <version>7.0.55</version>
         <type>zip</type>
         <scope>provided</scope>
     </dependency>
@@ -57,7 +57,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>hibernate4</artifactId>
-        <version>4.3.5.2</version>
+        <version>4.3.5.5</version>
         <type>zip</type>
         <scope>compile</scope>
     </dependency>   
@@ -65,7 +65,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>scaffolding</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.2</version>
         <type>zip</type>
         <scope>compile</scope>
     </dependency>   
@@ -78,11 +78,10 @@
         <scope>runtime</scope>
     </dependency> 
       
-    
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>asset-pipeline</artifactId>
-        <version>1.8.7</version>
+        <version>1.9.9</version>
         <type>zip</type>
         <scope>runtime</scope>
     </dependency> 
@@ -106,7 +105,7 @@
     <dependency>
         <groupId>org.grails.plugins</groupId>
         <artifactId>cache</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.8</version>
         <type>zip</type>
         <scope>runtime</scope>
     </dependency>                


### PR DESCRIPTION
To be able to create a new Grails Maven project using 2.4.3, I updated Grails version from 2.4.0.RC1 to 2.4.3 and some plugin dependencies :
- tomcat plugin from 7.0.52.1 to 7.0.55
- hibernate4 plugin from 4.3.5.2 to 4.3.5.5
- scaffolding plugin from 2.1.0 to 2.1.2
- asset-pipeline plugin from 1.8.7 to 1.9.9
- cache plugin from 1.1.3 to 1.1.8
